### PR TITLE
Remove mimic tags from ros2_control URDF in Panda descriptions

### DIFF
--- a/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -16,9 +16,6 @@
                 </state_interface>
             </joint>
             <joint name="${prefix}panda_finger_joint2">
-                <param name="mimic">${prefix}panda_finger_joint1</param>
-                <param name="multiplier">1</param>
-                <command_interface name="position" />
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>

--- a/panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -23,9 +23,6 @@
                 </state_interface>
             </joint>
             <joint name="panda_finger_joint2">
-                <param name="mimic">panda_finger_joint1</param>
-                <param name="multiplier">1</param>
-                <command_interface name="position" />
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>


### PR DESCRIPTION
I was trying to use this package on Rolling / Ubuntu 24.04 and ran into this problem.

Found it was related to https://github.com/ros-controls/ros2_control/pull/1553, in which the `<mimic>` tags have been deprecated as this information is now looked up directly from URDF.

So these tags, and command interfaces, for mimic joints, should be removed.