### PR TITLE
Add reasonable joint jerk limits for the Panda

### DIFF
--- a/panda_moveit_config/config/hard_joint_limits.yaml
+++ b/panda_moveit_config/config/hard_joint_limits.yaml
@@ -9,52 +9,61 @@ joint_limits:
     max_velocity: 2.1750
     has_acceleration_limits: true
     max_acceleration: 15.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint2:
     has_velocity_limits: true
     max_velocity: 2.1750
     has_acceleration_limits: true
     max_acceleration: 7.5
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint3:
     has_velocity_limits: true
     max_velocity: 2.1750
     has_acceleration_limits: true
     max_acceleration: 10.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint4:
     has_velocity_limits: true
     max_velocity: 2.1750
     has_acceleration_limits: true
     max_acceleration: 12.5
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint5:
     has_velocity_limits: true
     max_velocity: 2.6100
     has_acceleration_limits: true
     max_acceleration: 15.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint6:
     has_velocity_limits: true
     max_velocity: 2.6100
     has_acceleration_limits: true
     max_acceleration: 20.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint7:
     has_velocity_limits: true
     max_velocity: 2.6100
     has_acceleration_limits: true
     max_acceleration: 20.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_finger_joint1:
     has_velocity_limits: true
     max_velocity: 0.1
     has_acceleration_limits: true
     max_acceleration: 1.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_finger_joint2:
     has_velocity_limits: true
     max_velocity: 0.1
     has_acceleration_limits: true
     max_acceleration: 1.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0

--- a/panda_moveit_config/config/joint_limits.yaml
+++ b/panda_moveit_config/config/joint_limits.yaml
@@ -8,52 +8,61 @@ joint_limits:
     max_velocity: 2.1750
     has_acceleration_limits: true
     max_acceleration: 3.75
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint2:
     has_velocity_limits: true
     max_velocity: 2.1750
     has_acceleration_limits: true
     max_acceleration: 1.875
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint3:
     has_velocity_limits: true
     max_velocity: 2.1750
     has_acceleration_limits: true
     max_acceleration: 2.5
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint4:
     has_velocity_limits: true
     max_velocity: 2.1750
     has_acceleration_limits: true
     max_acceleration: 3.125
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint5:
     has_velocity_limits: true
     max_velocity: 2.6100
     has_acceleration_limits: true
     max_acceleration: 3.75
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint6:
     has_velocity_limits: true
     max_velocity: 2.6100
     has_acceleration_limits: true
     max_acceleration: 5.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_joint7:
     has_velocity_limits: true
     max_velocity: 2.6100
     has_acceleration_limits: true
     max_acceleration: 5.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_finger_joint1:
     has_velocity_limits: true
     max_velocity: 0.1
     has_acceleration_limits: true
     max_acceleration: 1.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0
   panda_finger_joint2:
     has_velocity_limits: true
     max_velocity: 0.1
     has_acceleration_limits: true
     max_acceleration: 1.0
-    has_jerk_limits: false
+    has_jerk_limits: true
+    max_jerk: 300.0


### PR DESCRIPTION
These jerk limits have been tested on a robot that's approximately UR5-sized.

I think it will be good to have jerk limits in this example so the jerk-limited smoothing features can be used, if desired.