### PR TITLE
add 'moveit2_tutorials' exec dependency

### DIFF
--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -29,6 +29,7 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   -->
+  <exec_depend>moveit2_tutorials</exec_depend>
   <exec_depend>ros2cli_common_extensions</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>


### PR DESCRIPTION
The `moveit2_tutorials` package is used here:
https://github.com/moveit/moveit_resources/blob/c55b102711fc0aebe80c6952d2ce97c38110abba/panda_moveit_config/launch/moveit_rviz.launch.py#L50
but it is not declared as runtime dependency.

The package and files in question are here:
https://github.com/moveit/moveit2_tutorials/tree/humble/doc/tutorials/quickstart_in_rviz/launch

In addition to this PR, the `moveit2_tutorials` package needs to be released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the required MoveIt tutorial package dependency to the Panda MoveIt configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->